### PR TITLE
fix: プレイ時間制限を10秒刻み・最大3分に変更

### DIFF
--- a/app/HiraganaMatchingGame/ViewModels/GameViewModel.swift
+++ b/app/HiraganaMatchingGame/ViewModels/GameViewModel.swift
@@ -76,7 +76,7 @@ class GameViewModel {
         
         // 時間制限の設定（テストモードでは無効）
         if !isTestMode, let settings = userSettings, settings.playtimeLimit > 0 {
-            timeRemaining = settings.playtimeLimit * 60 // 分を秒に変換
+            timeRemaining = settings.playtimeLimit // 既に秒単位
             startGameTimer()
         }
         

--- a/app/HiraganaMatchingGame/ViewModels/SettingsViewModel.swift
+++ b/app/HiraganaMatchingGame/ViewModels/SettingsViewModel.swift
@@ -192,12 +192,20 @@ class SettingsViewModel {
         return "\(Int(soundVolume * 100))%"
     }
     
-    // 制限時間のフォーマット
+    // 制限時間のフォーマット（秒単位）
     func formattedPlaytimeLimit() -> String {
         if playtimeLimit == 0 {
             return "制限なし"
+        } else if playtimeLimit < 60 {
+            return "\(playtimeLimit)秒"
         } else {
-            return "\(playtimeLimit)分"
+            let minutes = playtimeLimit / 60
+            let seconds = playtimeLimit % 60
+            if seconds == 0 {
+                return "\(minutes)分"
+            } else {
+                return "\(minutes)分\(seconds)秒"
+            }
         }
     }
     

--- a/app/HiraganaMatchingGameTests/UserSettingsTests.swift
+++ b/app/HiraganaMatchingGameTests/UserSettingsTests.swift
@@ -19,13 +19,13 @@ func settingsUpdate() {
     settings.updateSettings(
         soundEnabled: false,
         musicEnabled: false,
-        playtimeLimit: 30,
+        playtimeLimit: 120,
         voiceSpeed: 0.8
     )
     
     #expect(settings.soundEnabled == false)
     #expect(settings.musicEnabled == false)
-    #expect(settings.playtimeLimit == 30)
+    #expect(settings.playtimeLimit == 120)
     #expect(settings.voiceSpeed == 0.8)
 }
 


### PR DESCRIPTION
設定画面のプレイ時間制限を10秒刻み、最大3分（180秒）に変更しました。

## 変更内容
- 設定画面の時間制限を分単位から秒単位に変更
- 10秒刻みで最大180秒（3分）の設定が可能
- 表示フォーマットを秒/分で適切に表示するよう改善
- ゲームロジックから不要な分→秒変換を削除
- テストケースの値を秒単位に更新

Resolves #2

Generated with [Claude Code](https://claude.ai/code)