### PR TITLE
fix: ゲーム結果画面のスキップ問題を修正

### DIFF
--- a/app/HiraganaMatchingGame/ContentView.swift
+++ b/app/HiraganaMatchingGame/ContentView.swift
@@ -69,9 +69,8 @@ struct ContentView: View {
                         userSettings: settings,
                         onGameComplete: { completedLevel, stars in
                             // Level completion is handled by GameViewModel
-                            // Just save the progress and return to level selection
+                            // Just save the progress - navigation handled by GameView
                             levelSelectionViewModel.saveProgress()
-                            currentScreen = .levelSelection
                         },
                         onBackToLevelSelection: {
                             currentScreen = .levelSelection
@@ -95,9 +94,8 @@ struct ContentView: View {
                         levelProgressionService: levelSelectionViewModel.levelProgressionService,
                         onGameComplete: { completedLevel, stars in
                             // Level completion is handled by GameViewModel
-                            // Just save the progress and return to level selection
+                            // Just save the progress - navigation handled by GameView
                             levelSelectionViewModel.saveProgress()
-                            currentScreen = .levelSelection
                         },
                         onBackToLevelSelection: {
                             currentScreen = .levelSelection


### PR DESCRIPTION
Fixes ###3

## 概要
ゲーム結果画面がスキップされる問題を修正しました。

## 変更内容
- `onGameComplete`コールバックから即座のナビゲーション処理を削除
- 進捗保存機能は維持
- GameViewの結果画面が正常に表示されるよう修正

## テスト方法
1. ゲームを完了する
2. 結果画面（スコア、スター評価、ボタン群）が表示されることを確認
3. ユーザーが明示的にボタンを押すことでのみナビゲーションが発生することを確認

Generated with [Claude Code](https://claude.ai/code)