### PR TITLE
Fix settings bug: Add missing playtimeLimit and questionsPerSession properties

### DIFF
--- a/app/HiraganaMatchingGame/Services/UserSettingsManager.swift
+++ b/app/HiraganaMatchingGame/Services/UserSettingsManager.swift
@@ -130,6 +130,30 @@ class UserSettingsManager: ObservableObject {
         }
     }
     
+    var playtimeLimit: Int {
+        get { settings?.playtimeLimit ?? 0 }
+        set { 
+            settings?.playtimeLimit = newValue
+            saveSettings()
+        }
+    }
+    
+    var questionsPerSession: Int {
+        get { settings?.questionsPerSession ?? 5 }
+        set { 
+            settings?.setQuestionsPerSession(newValue)
+            saveSettings()
+        }
+    }
+    
+    var questionsPerSessionEnum: QuestionsPerSession {
+        get { settings?.questionsPerSessionEnum ?? .few }
+        set { 
+            settings?.setQuestionsPerSessionEnum(newValue)
+            saveSettings()
+        }
+    }
+    
     // MARK: - Tutorial Management
     func markTutorialAsCompleted() {
         hasSeenTutorial = true


### PR DESCRIPTION
Fixes issue where game settings were not being reflected in gameplay.

Added missing properties to UserSettingsManager:
- playtimeLimit for time limit settings
- questionsPerSession for question count settings

Resolves #6

Generated with [Claude Code](https://claude.ai/code)